### PR TITLE
Taetse/fast compression

### DIFF
--- a/pkg/config/dynamic/tcp_middlewares.go
+++ b/pkg/config/dynamic/tcp_middlewares.go
@@ -41,8 +41,10 @@ type TCPStreamCompress struct {
 	Algorithm string `json:"algorithm,omitempty" toml:"algorithm,omitempty" yaml:"algorithm,omitempty"`
 	// Dictionary is an optional path to a zstd dictionary file
 	Dictionary string `json:"dictionary,omitempty" toml:"dictionary,omitempty" yaml:"dictionary,omitempty"`
-	// Level is the compression level to use
-	Level int `json:"level,omitempty" toml:"level,omitempty" yaml:"level,omitempty"`
+	// Level is the compression level to use. Can be one of the following: fastest, default, better, best
+	Level string `json:"level,omitempty" toml:"level,omitempty" yaml:"level,omitempty"`
+	// Upstream defines whether the compression should be applied to the upstream or downstream connection.
+	Upstream bool `json:"upstream,omitempty" toml:"upstream,omitempty" yaml:"upstream,omitempty"`
 }
 
 // TCPIPAllowList holds the TCP IPAllowList middleware configuration.

--- a/pkg/middlewares/tcp/streamcompress/stream_compress_test.go
+++ b/pkg/middlewares/tcp/streamcompress/stream_compress_test.go
@@ -1,0 +1,236 @@
+package tcpstreamcompress
+
+import (
+	"context"
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/traefik/traefik/v3/pkg/config/dynamic"
+	"github.com/traefik/traefik/v3/pkg/tcp"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+const message = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"
+
+type mockHandler struct{}
+
+func (m *mockHandler) ServeTCP(conn tcp.WriteCloser) {}
+
+func TestNewStreamCompressWithValidZstdAlgorithm(t *testing.T) {
+	config := dynamic.TCPStreamCompress{
+		Algorithm: "zstd",
+		Level:     "default",
+		Upstream:  false,
+	}
+	_, err := New(context.Background(), &mockHandler{}, config, "test")
+	require.NoError(t, err)
+}
+
+func TestNewStreamCompressWithInvalidAlgorithm(t *testing.T) {
+	config := dynamic.TCPStreamCompress{
+		Algorithm: "invalid",
+		Level:     "default",
+		Upstream:  false,
+	}
+	_, err := New(context.Background(), &mockHandler{}, config, "test")
+	assert.Error(t, err)
+}
+
+func TestNewStreamCompressWithInvalidLevel(t *testing.T) {
+	config := dynamic.TCPStreamCompress{
+		Algorithm: "zstd",
+		Level:     "invalid",
+		Upstream:  false,
+	}
+	_, err := New(context.Background(), &mockHandler{}, config, "test")
+	assert.Error(t, err)
+}
+
+func TestNewStreamCompressWithInvalidDictionary(t *testing.T) {
+	config := dynamic.TCPStreamCompress{
+		Algorithm:  "zstd",
+		Level:      "default",
+		Upstream:   false,
+		Dictionary: "invalid",
+	}
+	_, err := New(context.Background(), &mockHandler{}, config, "test")
+	assert.Error(t, err)
+}
+
+func TestStreamCompress_ServeTCP(t *testing.T) {
+	next := tcp.HandlerFunc(func(conn tcp.WriteCloser) {
+		// will write to decompressor(compresses data) -> compressor(decompresses data) -> client -> server
+		write, err := conn.Write([]byte(message))
+		// sleep for a bit to ensure the flush block is sent
+		time.Sleep(100 * time.Millisecond)
+		require.NoError(t, err)
+		assert.Equal(t, len(message), write)
+
+		err = conn.Close()
+		require.NoError(t, err)
+	})
+
+	decompressorConfig := dynamic.TCPStreamCompress{
+		Algorithm: "zstd",
+		Level:     "best",
+		Upstream:  true,
+	}
+
+	// Pipeline is now decompressor ⇌ echo function
+	decompressor, err := New(context.Background(), next, decompressorConfig, "traefikTest2")
+	require.NoError(t, err)
+
+	compressorConfig := dynamic.TCPStreamCompress{
+		Algorithm: "zstd",
+		Level:     "best",
+		Upstream:  false,
+	}
+
+	// Pipeline is now compressor ⇌ decompressor ⇌ echo function
+	compressor, err := New(context.Background(), decompressor, compressorConfig, "traefikTest")
+	require.NoError(t, err)
+
+	server, client := net.Pipe()
+
+	go func() {
+		// Pipeline is now server ⇌ client ⇌ compressor ⇌ decompressor ⇌ echo function
+		compressor.ServeTCP(&contextWriteCloser{client, addr{"10.10.10.10"}})
+	}()
+
+	// Read the data from the server. The data is originating from echo function -> decompressor(compresses data) -> compressor(decompresses data) -> client -> server
+	read, err := io.ReadAll(server)
+	require.NoError(t, err)
+
+	assert.Equal(t, message, string(read))
+
+	err = server.Close()
+	require.NoError(t, err)
+}
+
+func TestStreamCompress_ServeTCPCompression(t *testing.T) {
+	next := tcp.HandlerFunc(func(conn tcp.WriteCloser) {
+		// will write to decompressor(compresses data) -> client -> server.
+		write, err := conn.Write([]byte(message))
+		require.NoError(t, err)
+		assert.Equal(t, len(message), write)
+
+		err = conn.Close()
+		require.NoError(t, err)
+	})
+
+	decompressorConfig := dynamic.TCPStreamCompress{
+		Algorithm: "zstd",
+		Level:     "best",
+		Upstream:  true,
+	}
+
+	// Pipeline is now decompressor ⇌ echo function
+	decompressor, err := New(context.Background(), next, decompressorConfig, "traefikTest3")
+	require.NoError(t, err)
+
+	server, client := net.Pipe()
+
+	go func() {
+		// Pipeline is now server ⇌ client ⇌ decompressor ⇌ echo function
+		decompressor.ServeTCP(&contextWriteCloser{client, addr{"10.10.10.10"}})
+	}()
+
+	// Read the compressed data from the server. The data is originating from echo function -> decompressor(compresses data) -> client -> server
+	readCompressed, err := io.ReadAll(server)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, []byte(message), readCompressed)
+
+	decoder, err := zstd.NewReader(nil)
+	require.NoError(t, err)
+
+	read, err := decoder.DecodeAll(readCompressed, nil)
+
+	assert.Equal(t, message, string(read))
+
+	err = server.Close()
+	require.NoError(t, err)
+
+	decoder.Close()
+}
+
+func TestStreamCompress_ServeTCPDecompression(t *testing.T) {
+	compressor, err := zstd.NewWriter(nil)
+	require.NoError(t, err)
+
+	compressedMessage := compressor.EncodeAll([]byte(message), nil)
+	assert.NotEqual(t, []byte(message), compressedMessage)
+
+	err = compressor.Close()
+	require.NoError(t, err)
+
+	next := tcp.HandlerFunc(func(conn tcp.WriteCloser) {
+		// will write compressed data to decompressor(decompresses data) -> client -> server.
+		write, err := conn.Write(compressedMessage)
+		require.NoError(t, err)
+		assert.Equal(t, len(compressedMessage), write)
+
+		time.Sleep(100 * time.Millisecond)
+
+		err = conn.Close()
+		require.NoError(t, err)
+	})
+
+	decompressorConfig := dynamic.TCPStreamCompress{
+		Algorithm: "zstd",
+		Level:     "best",
+		Upstream:  false,
+	}
+
+	// Pipeline is now decompressor ⇌ echo function
+	decompressor, err := New(context.Background(), next, decompressorConfig, "traefikTest3")
+	require.NoError(t, err)
+
+	server, client := net.Pipe()
+
+	go func() {
+		// Pipeline is now server ⇌ client ⇌ decompressor ⇌ echo function
+		decompressor.ServeTCP(&contextWriteCloser{client, addr{"10.10.10.10"}})
+	}()
+
+	// Read the decompressed data from the server. The data is originating from echo function -> decompressor(decompresses data) -> client -> server
+	read, err := io.ReadAll(server)
+	require.NoError(t, err)
+
+	assert.Equal(t, message, string(read))
+
+	err = server.Close()
+	require.NoError(t, err)
+}
+
+type contextWriteCloser struct {
+	net.Conn
+	addr
+}
+
+type addr struct {
+	remoteAddr string
+}
+
+func (a addr) Network() string {
+	panic("implement me")
+}
+
+func (a addr) String() string {
+	return a.remoteAddr
+}
+
+func (c contextWriteCloser) CloseWrite() error {
+	panic("implement me")
+}
+
+func (c contextWriteCloser) RemoteAddr() net.Addr {
+	return c.addr
+}
+
+func (c contextWriteCloser) Context() context.Context {
+	return context.Background()
+}

--- a/pkg/middlewares/tcp/streamcompress/stream_compress_test.go
+++ b/pkg/middlewares/tcp/streamcompress/stream_compress_test.go
@@ -208,8 +208,9 @@ func TestStreamCompress_ServeTCPDecompression(t *testing.T) {
 
 func layeredCompressor(next tcp.Handler, layers int, config dynamic.TCPStreamCompress) tcp.Handler {
 	config.Upstream = true
+	ctx := context.Background()
 	for i := 0; i < (layers * 2); i++ {
-		next, _ = New(context.Background(), next, config, "traefikTest")
+		next, _ = New(ctx, next, config, "traefikTest")
 		config.Upstream = !config.Upstream
 	}
 	return next
@@ -228,7 +229,7 @@ func BenchmarkLayeredStreamCompress(b *testing.B) {
 		require.NoError(b, err)
 		assert.Equal(b, len(data), write)
 
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(time.Duration(numberOfLayers) * time.Millisecond)
 
 		err = conn.Close()
 		require.NoError(b, err)

--- a/pkg/middlewares/tcp/streamcompress/zstd.go
+++ b/pkg/middlewares/tcp/streamcompress/zstd.go
@@ -64,7 +64,7 @@ func (z *zstdDecompressor) Write(p []byte) (n int, err error) {
 }
 
 func (z *zstdDecompressor) Close() error {
-	z.WriteCloser.SetDeadline(time.Now().Add(time.Millisecond))
+	z.WriteCloser.SetDeadline(time.Now().Add(10 * time.Millisecond))
 	defer z.mu.Unlock()
 	defer z.muW.Unlock()
 	z.mu.Lock()
@@ -79,7 +79,7 @@ func (z *zstdDecompressor) Close() error {
 	return err
 }
 func (z *zstdDecompressor) CloseWrite() error {
-	z.WriteCloser.SetWriteDeadline(time.Now().Add(time.Millisecond))
+	z.WriteCloser.SetWriteDeadline(time.Now().Add(10 * time.Millisecond))
 	defer z.muW.Unlock()
 	z.muW.Lock()
 


### PR DESCRIPTION
Layer test metrics:
![image](https://github.com/user-attachments/assets/afd57cc5-7c6c-4c6e-b1d2-807798ff628f)

Concurrent client metrics:
![image](https://github.com/user-attachments/assets/d50a5e5b-3b31-4236-b1cc-31e97aeec1d2)
